### PR TITLE
Unifies Contains/Expect mimic functions, implements Fd() uintptr

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -17,11 +17,11 @@ func ExampleMimic_ContainsString() {
 	text := strings.Repeat("Hi", 16)
 	_, _ = m.WriteString(text)
 
-	if err := m.ContainsString(text); err != nil {
+	if err := m.ExpectString(text); err != nil {
 		println("The text should have wrapped!")
 	}
 
-	if err := m.ContainsString(strings.Repeat("Hi", 15)); err != nil {
+	if err := m.ExpectString(strings.Repeat("Hi", 15)); err != nil {
 		fmt.Printf("Found: %s\n\n", strings.Repeat("Hi", 15))
 	}
 

--- a/mimic_test.go
+++ b/mimic_test.go
@@ -2,6 +2,7 @@ package mimic
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -33,52 +34,52 @@ func TestMimic_ContainsPattern(t *testing.T) {
 		name     string
 		contents string
 		pattern  []string
-		wantErr  bool
+		want     bool
 	}{
 		{name: "simple pattern matches found", contents: "Hello, World!", pattern: []string{
 			".*Hello.*",
 			".*World.*",
 			"[hH]ello,\\s[wW]orld!",
-		}, wantErr: false},
+		}, want: true},
 
 		{name: "simple pattern matches not found", contents: "Hello, World!", pattern: []string{
 			".*puppies.*",
-		}, wantErr: true},
+		}, want: false},
 
 		{name: "complex pattern matches found", contents: "H3ll0,\nWor1d! XXXXXXXXXXXXXXXXXXXXX", pattern: []string{
 			"^H3ll0.*",
 			"^.*[\n].*[xX]{3,}$",
 			".*XXXX$",
 			"[h-lH-L0-3]+",
-		}, wantErr: false},
+		}, want: true},
 
 		{name: "escapes ansi", contents: "\x1b[38;5;140mfoo\x1b[0m bar", pattern: []string{
 			"foo",
 			"foo bar",
 			"^foo\\sbar$",
 			"bar",
-		}, wantErr: false},
+		}, want: true},
 
-		{name: "escapes ansi complex", contents: "\u001B[0m\u001B[4m\u001B[42m\u001B[31mfoo\u001B[39m\u001B[49m\u001B[24mfoo\u001B[0m", pattern: []string{
+		{name: "escapes ansi complex", contents: "\x1b[0m\x1b[4m\x1b[42m\x1b[31mfoo\x1b[39m\x1b[49m\x1b[24mfoo\x1b[0m", pattern: []string{
 			"^foofoo$",
-		}, wantErr: false},
+		}, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := NewMimic(WithIdleDuration(5 * time.Millisecond))
+			m, err := NewMimic(WithIdleDuration(15 * time.Millisecond))
 			assert.NoError(t, err)
 
 			_, err = m.WriteString(tt.contents)
 			assert.NoError(t, err)
 
-			if err := m.ContainsPattern(tt.pattern...); (err != nil) != tt.wantErr {
-				t.Errorf("ContainsPattern() error = %#v, wantErr %v", err, tt.wantErr)
+			if m.ContainsPattern(tt.pattern...) && !tt.want {
+				t.Errorf("ExpectPattern() did not match expected result %v", tt.want)
 			}
 		})
 	}
 }
 
-func TestMimic_ContainsString(t *testing.T) {
+func TestMimic_ExpectString(t *testing.T) {
 	tests := []struct {
 		name     string
 		contents string
@@ -96,15 +97,52 @@ func TestMimic_ContainsString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := NewMimic(WithIdleDuration(5 * time.Millisecond))
+			m, err := NewMimic(WithIdleDuration(20 * time.Millisecond))
 			assert.NoError(t, err)
 
 			_, err = m.WriteString(tt.contents)
 			assert.NoError(t, err)
 
-			if err := m.ContainsString(tt.contains...); (err != nil) != tt.wantErr {
-				t.Errorf("ContainsString() error = %v, wantErr %v", err, tt.wantErr)
+			if err := m.ExpectString(tt.contains...); (err != nil) != tt.wantErr {
+				t.Errorf("ExpectString() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func TestMimic_ExpectPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		pattern  []string
+		wantErr  assert.ErrorAssertionFunc
+	}{
+		{name: "simple pattern matches found", contents: "Hello, World!", pattern: []string{
+			".*Hello.*",
+			".*World.*",
+			"[hH]ello,\\s[wW]orld!",
+		}, wantErr: assert.NoError},
+
+		{name: "simple pattern matches not found", contents: "Hello, World!", pattern: []string{
+			".*puppies.*",
+		}, wantErr: assert.Error},
+
+		{name: "complex pattern with newline should not match as found", contents: "H3ll0,\nWor1d! XXXXXXXXXXXXXXXXXXXXX", pattern: []string{
+			"^H3ll0.*",
+			"^.*[\n].*[xX]{3,}$",
+			".*XXXX$",
+			"[h-lH-L0-3]+",
+		}, wantErr: assert.NoError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := NewMimic(WithIdleDuration(20 * time.Millisecond))
+			assert.NoError(t, err)
+
+			_, err = m.WriteString(tt.contents)
+			assert.NoError(t, err)
+
+			tt.wantErr(t, m.ExpectPattern(tt.pattern...), fmt.Sprintf("ExpectPattern(%v)", tt.pattern))
 		})
 	}
 }

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -61,12 +61,12 @@ func (m *MyTests) TestMimicWriteRead() {
 	assert.NoError(m.T(), err, "pty should have allowed the write!")
 	assert.Equal(m.T(), written, fullWriteWidth, "pty should have written all bytes!")
 
-	assert.NoError(m.T(), console.ContainsString(full), "Emulated terminal should be %d columns, not %d columns as the written string", terminalWidth, fullWriteWidth)
-	assert.Error(m.T(), console.ContainsString(strings.Repeat(character, terminalWidth+1)), "Emulated terminal should be %d columns, but found %d characters", terminalWidth, terminalWidth+1)
-	assert.Error(m.T(), console.ContainsString(strings.Repeat(character, terminalWidth)), "Emulated terminal should have wrapped text at %d columns", terminalWidth)
+	assert.NoError(m.T(), console.ExpectString(full), "Emulated terminal should be %d columns, not %d columns as the written string", terminalWidth, fullWriteWidth)
+	assert.Error(m.T(), console.ExpectString(strings.Repeat(character, terminalWidth+1)), "Emulated terminal should be %d columns, but found %d characters", terminalWidth, terminalWidth+1)
+	assert.Error(m.T(), console.ExpectString(strings.Repeat(character, terminalWidth)), "Emulated terminal should have wrapped text at %d columns", terminalWidth)
 
-	assert.False(m.T(), console.ViewMatches(full), "underlying terminal is expected to wrap")
-	assert.True(m.T(), console.ViewMatches(strings.Repeat(character, terminalWidth)+"\n"+strings.Repeat(character, wrapLength)), "underlying terminal is expected to wrap")
+	assert.False(m.T(), console.ContainsString(full), "underlying terminal is expected to wrap")
+	assert.True(m.T(), console.ContainsString(strings.Repeat(character, terminalWidth)+"\n"+strings.Repeat(character, wrapLength)), "underlying terminal is expected to wrap")
 }
 
 func (m *MyTests) TestMimicWaitingForIdle() {
@@ -104,8 +104,8 @@ func (m *MyTests) TestMimicWaitingForIdle() {
 		return
 	}
 
-	assert.NoError(m.T(), console.ContainsString(strings.Repeat(".", targetCount)), "Console didn't include expected contents… Was: empty")
-	assert.Error(m.T(), console.ContainsString(strings.Repeat(".", targetCount+2)), "Console did not include expected contents… Was: empty")
+	assert.NoError(m.T(), console.ExpectString(strings.Repeat(".", targetCount)), "Console didn't include expected contents… Was: empty")
+	assert.Error(m.T(), console.ExpectString(strings.Repeat(".", targetCount+2)), "Console did not include expected contents… Was: empty")
 }
 
 func TestMimicOperationsSuite(t *testing.T) {


### PR DESCRIPTION
* Maintains Expect* returning error and Contains* returning bool. Updates tests.
* Implements Fd() uintptr so mimic can be used in place of stdio In/Out/Err in go-survey/survey