### PR TITLE
feat: mimic Flush/NoMoreExpectations/Experimental 

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -1,0 +1,26 @@
+%YAML 1.1
+---
+resolve: commits
+owner: jimschubert
+repo: mimic
+groupings:
+  - name: Functionality
+    patterns: ['(?i)^new\b', '(?i)^initial\b', '(?i)^support\b', '(?i)^introduce\b', '(?i)^feat\b']
+  - name: Fixes
+    patterns: ['(?i)^fix\b', '(?i)^bug', '(?i).*fixes$']
+  - name: Uncategorized
+    patterns: ['.*']
+exclude:
+  - '^(?i)wip\b'
+  - '^(?i)help\b'
+  - '^(?i)doc\b'
+  - '^(?i)docs\b'
+  - '^(?i)test\b'
+  - '^(?i)trying\b'
+  - '^(?i)workflow\b'
+  - '^(?i)update readme\b'
+  - '^(?i)style\b'
+  - '^(?i)chore\b'
+sort: asc
+max_commits: 250
+local: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters-settings:
   stylecheck:
     checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
     dot-import-whitelist:
-      - vcr
+      - mimic
     # https://staticcheck.io/docs/configuration/options/#initialisms
     initialisms:
     - API
@@ -53,7 +53,6 @@ linters-settings:
     - URI
     - URL
     - UUID
-    - VCR
     - VHS
     - XML
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,144 @@
+/*
+Package mimic provides a utility for interacting with console or terminal based applications.
+
+A mimic/Mimic internally constructs two pseudo-terminals: one wrapping go-expect,
+and another construct of creak/pty. This allows for either stream-based or view-based inspection of strings/patterns.
+
+The key difference between the two is that stream-based inspections provided by
+Mimic.ExpectString and Mimic.ExpectPattern will wait for a configurable amount
+of time for any text matching the criteria, then _fail_ if no match is found. The search
+criteria passed to these functions is evaluated repeatedly as bytes are written to your
+output stream. Keep this in mind, as very complex patterns can be slow. The underlying views are raw pty,
+and the output is therefore not formatted as it would be within a terminal.
+
+The view-based inspections provided by Mimic.ContainsString and Mimic.ContainsPattern,
+on the other hand, will wait for the bound output stream to complete processing before applying
+the search criteria to the entire formatted view. This takes configurable terminal columns/rows
+into account. These default to a large standard of 132 columns and 24 rows. Internally, this is implemented
+via github.com/hinshun/vt10x.
+
+Usage
+
+A mimic value implements io.ReadWriteCloser and also satisfies the following interfaces:
+
+	 type fileWriter interface {
+		io.Writer
+		Fd() uintptr
+	 }
+
+	 type fileReader interface {
+		io.Reader
+		Fd() uintptr
+	 }
+
+This allows Mimic values to be used in place of Stdin/Stdout/Stderr in most scenarios, including
+implementations using github.com/AlecAivazis/survey/v2. For example:
+
+	 package main
+
+	 import (
+		"fmt"
+		"os"
+
+		"github.com/AlecAivazis/survey/v2"
+		"github.com/jimschubert/mimic"
+	 )
+
+	 func main() {
+		console, _ := mimic.NewMimic()
+		answers := struct {
+			Name string
+			Age  int
+		}{}
+
+		go func() {
+			// errors ignored for brevity
+			console.ExpectString("What is your name?")
+			console.WriteString("Tom\n")
+			console.ExpectString("How old are you?")
+			console.WriteString("20\n")
+			console.ExpectString("Tom", "20")
+			if !console.ContainsString("What is your name?", "How old are you?", "Tom", "20") {
+				panic("My answers weren't displayed!")
+			}
+			_ = console.NoMoreExpectations()
+		}()
+
+		_ = survey.Ask([]*survey.Question{
+			{Name: "name", Prompt: &survey.Input{Message: "What is your name?"}},
+			{Name: "age", Prompt: &survey.Input{Message: "How old are you?"}},
+		}, &answers,
+			survey.WithStdio(console.Tty(), console.Tty(), console.Tty()),
+		)
+		fmt.Fprintf(os.Stdout, "%s is %d.\n", answers.Name, answers.Age)
+	 }
+
+Notice in the above example that all expectations should be invoked asynchronously from the thread being instrumented.
+
+Testing
+
+Mimic provides a Suite based on github.com/stretchr/testify/suite which allows creation of a new mimic per test, or
+a suite-level mimic can be created for more advanced scenarios. Embed suite.Suite into a test struct, then add Test* functions
+to implement your tests. Follow testify's documentation for more. Here's an slimmed-down example from mimic's own tests:
+
+	  package suite
+
+	  import (
+		"context"
+		"io"
+		"strings"
+		"testing"
+		"time"
+
+		"github.com/jimschubert/mimic"
+		"github.com/stretchr/testify/assert"
+		"github.com/stretchr/testify/suite"
+	  )
+
+	  type MyTests struct {
+		Suite
+		suiteRuntimeDuration time.Duration
+	  }
+
+	  func (m *MyTests) SetupSuite() {
+		assert.Greaterf(m.T(), m.suiteRuntimeDuration, 0*time.Second, "Suite runtime must be marked as more than 0 units of time")
+	  }
+
+	  func (m *MyTests) TestMimicWriteRead() {
+		m.T().Log("Invoked TestMimicWithOptions")
+		terminalWidth := 80
+		wrapLength := 20
+		console, err := m.Mimic(
+			mimic.WithIdleDuration(25*time.Millisecond),
+			mimic.WithIdleTimeout(1*time.Second),
+			mimic.WithSize(24, terminalWidth),
+		)
+
+		assert.NoError(m.T(), err, "Standard invocation with options should not produce an error")
+		assert.NotNil(m.T(), console, "Mimic instance must should not be nil on errorless construction")
+
+		character := "X"
+		fullWriteWidth := terminalWidth + wrapLength
+		full := strings.Repeat(character, fullWriteWidth)
+		written, err := console.WriteString(full)
+
+		assert.NoError(m.T(), err, "pty should have allowed the write!")
+		assert.Equal(m.T(), written, fullWriteWidth, "pty should have written all bytes!")
+
+		assert.NoError(m.T(), console.ExpectString(full), "Emulated terminal should be %d columns, not %d columns as the written string", terminalWidth, fullWriteWidth)
+		assert.Error(m.T(), console.ExpectString(strings.Repeat(character, terminalWidth+1)), "Emulated terminal should be %d columns, but found %d characters", terminalWidth, terminalWidth+1)
+		assert.Error(m.T(), console.ExpectString(strings.Repeat(character, terminalWidth)), "Emulated terminal should have wrapped text at %d columns", terminalWidth)
+
+		assert.False(m.T(), console.ContainsString(full), "underlying terminal is expected to wrap")
+		assert.True(m.T(), console.ContainsString(strings.Repeat(character, terminalWidth)+"\n"+strings.Repeat(character, wrapLength)), "underlying terminal is expected to wrap")
+	  }
+
+	  func TestMimicOperationsSuite(t *testing.T) {
+		test := new(MyTests)
+		test.suiteRuntimeDuration = 30 * time.Second
+		test.Init(WithMaxRuntime(test.suiteRuntimeDuration))
+
+		suite.Run(t, test)
+	  }
+*/
+package mimic

--- a/example_test.go
+++ b/example_test.go
@@ -34,3 +34,21 @@ func ExampleMimic_ContainsString() {
 	// HiHiHiHiHiHiHiHiHiHiHiHiHiHiHi
 	// Hi
 }
+
+func ExampleViewer_String() {
+	m, _ := mimic.NewMimic(
+		mimic.WithSize(24, 80),
+		mimic.WithIdleTimeout(300*time.Millisecond),
+	)
+
+	text := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Sed vulputate odio ut enim blandit volutpat maecenas volutpat."
+	_, _ = m.WriteString(text)
+	_ = m.NoMoreExpectations()
+	formatted := mimic.Viewer{Mimic: m, StripAnsi: true, Trim: true}
+	fmt.Printf("%s\n", formatted.String())
+
+	// Output:
+	// Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
+	// ncididunt ut labore et dolore magna aliqua. Sed vulputate odio ut enim blandit v
+	// olutpat maecenas volutpat.
+}

--- a/exp.go
+++ b/exp.go
@@ -1,0 +1,32 @@
+package mimic
+
+import (
+	"errors"
+
+	"github.com/Netflix/go-expect"
+	"github.com/hinshun/vt10x"
+)
+
+// An Experimental contract which can be changed or removed at any time.
+// This is intended for use by users for experimentation purposes only.
+type Experimental interface {
+	// Console provides access to the underlying expect.Console
+	Console() (expect.Console, error)
+	// Terminal provides access to the underlying vt10x.Terminal
+	Terminal() (vt10x.Terminal, error)
+}
+
+type exp Mimic
+
+// Console provides access to the underlying expect.Console
+func (e exp) Console() (expect.Console, error) {
+	if e.console == nil {
+		return expect.Console{}, errors.New("console is uninitialized")
+	}
+	return *e.console, nil
+}
+
+// Terminal provides access to the underlying vt10x.Terminal
+func (e exp) Terminal() (vt10x.Terminal, error) {
+	return e.terminal, nil
+}

--- a/view.go
+++ b/view.go
@@ -6,26 +6,29 @@ import (
 	"github.com/jimschubert/stripansi"
 )
 
+// Viewer is a utility for providing a String function on a mimic value.
+// This is intentionally separated from mimic.Mimic to allow for multiple outputs
+// for a single mimic, and to remove any confusion about what String might refer to.
 type Viewer struct {
 	Mimic     *Mimic
 	StripAnsi bool
 	Trim      bool
 }
 
+// String provides the full underlying dump of the terminal's view.
 func (v *Viewer) String() string {
 	if v.Mimic == nil {
 		return ""
 	}
 
-	var altered string
-	original := v.Mimic.terminal.String()
+	result := v.Mimic.terminal.String()
 	if v.Trim {
-		altered = strings.TrimSpace(original)
+		result = strings.TrimSpace(result)
 	}
 
 	if v.StripAnsi {
-		altered = stripansi.String(altered)
+		result = stripansi.String(result)
 	}
 
-	return altered
+	return result
 }


### PR DESCRIPTION
* Added mimic functions for `Flush` and `NoMoreExpectations`
* Added an Experimental field, which exposes underlying console/terminal references for experimentation
* Changes vt10x to stdin/stdout pipes rather than using SendObserver
* fix: viewer no longer fails if either option not set
* doc: package docs, changelog